### PR TITLE
Added sqlalchemy dependency for Money in Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       context: https://github.com/puckel/docker-airflow.git#1.10.1
       dockerfile: Dockerfile
       args:
-        AIRFLOW_DEPS: gcp_api,s3        
+        AIRFLOW_DEPS: gcp_api,s3       
+        PYTHON_DEPS: sqlalchemy==1.2.0
     restart: always
     depends_on:
       - postgres


### PR DESCRIPTION
Hello Tuan,

The docker image wasn't running due to an error with the sqlalchemy dependency (https://github.com/tuanavu/airflow-tutorial/issues/23):
AttributeError: module 'sqlalchemy.dialects.postgresql' has no attribute 'MONEY'

Adding a python dependency sqlalchemy==1.2.0 fixes this problem.

Please let me know what you think.

Also, thanks so much for your tutorial on airflow.  It is super useful!